### PR TITLE
feat configs: don't duplicate dbconnection in config_vars, pass it through env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ format:
 
 # Internal hidden targets that are used only in docker environment
 --in-docker-start-debug --in-docker-start-release: --in-docker-start-%: install-%
-	psql 'postgresql://user:password@service-postgres:5432/pg_service_template_db_1' -f ./postgresql/data/initial_data.sql
+	psql ${DB_CONNECTION} -f ./postgresql/data/initial_data.sql
 	/home/user/.local/bin/pg_service_template \
 		--config /home/user/.local/etc/pg_service_template/static_config.yaml \
 		--config_vars /home/user/.local/etc/pg_service_template/config_vars.docker.yaml

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ format:
 	find src -name '*pp' -type f | xargs $(CLANG_FORMAT) -i
 	find tests -name '*.py' -type f | xargs autopep8 -i
 
+# Set environment for --in-docker-start
+export DB_CONNECTION := postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@service-postgres:5432/${POSTGRES_DB}
+
 # Internal hidden targets that are used only in docker environment
 --in-docker-start-debug --in-docker-start-release: --in-docker-start-%: install-%
 	psql ${DB_CONNECTION} -f ./postgresql/data/initial_data.sql

--- a/configs/config_vars.docker.yaml
+++ b/configs/config_vars.docker.yaml
@@ -5,5 +5,3 @@ logger-level: debug
 is-testing: false
 
 server-port: 8080
-
-dbconnection: 'postgresql://user:password@service-postgres:5432/pg_service_template_db_1'

--- a/configs/static_config.yaml
+++ b/configs/static_config.yaml
@@ -57,6 +57,7 @@ components_manager:
 
         postgres-db-1:
             dbconnection: $dbconnection
+            dbconnection#env: DB_CONNECTION
             blocking_task_processor: fs-task-processor
             dns_resolver: async
             sync-start: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,7 @@ services:
     postgres:
         container_name: service-postgres
         image: postgres:12
-        environment:
-          - POSTGRES_DB=pg_service_template_db_1
-          - POSTGRES_USER=user
-          - POSTGRES_PASSWORD=password
+        env_file: docker-database.env
         ports:
           - 5432
         volumes:
@@ -19,10 +16,8 @@ services:
     pg_service_template-container:
         image: ghcr.io/userver-framework/ubuntu-22.04-userver-pg:latest
         privileged: true
+        env_file: docker-database.env
         environment:
-          - POSTGRES_DB=pg_service_template_db_1
-          - POSTGRES_USER=user
-          - POSTGRES_PASSWORD=password
           - PREFIX=${PREFIX:-~/.local}
           - CCACHE_DIR=/pg_service_template/.ccache
           - CORES_DIR=/cores

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     postgres:
         container_name: service-postgres
         image: postgres:12
-        env_file: docker-database.env
+        environment: &db_env
+          POSTGRES_DB: pg_service_template_db_1
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
         ports:
           - 5432
         volumes:
@@ -16,11 +19,11 @@ services:
     pg_service_template-container:
         image: ghcr.io/userver-framework/ubuntu-22.04-userver-pg:latest
         privileged: true
-        env_file: docker-database.env
         environment:
-          - PREFIX=${PREFIX:-~/.local}
-          - CCACHE_DIR=/pg_service_template/.ccache
-          - CORES_DIR=/cores
+          <<: *db_env
+          PREFIX: ${PREFIX:-~/.local}
+          CCACHE_DIR: /pg_service_template/.ccache
+          CORES_DIR: /cores
         volumes:
           - .:/pg_service_template:rw
           - ${TC_CORES_DIR:-./.cores}:/cores:rw

--- a/docker-database.env
+++ b/docker-database.env
@@ -1,0 +1,4 @@
+POSTGRES_DB=pg_service_template_db_1
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password
+DB_CONNECTION=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@service-postgres:5432/${POSTGRES_DB}

--- a/docker-database.env
+++ b/docker-database.env
@@ -1,4 +1,0 @@
-POSTGRES_DB=pg_service_template_db_1
-POSTGRES_USER=user
-POSTGRES_PASSWORD=password
-DB_CONNECTION=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@service-postgres:5432/${POSTGRES_DB}


### PR DESCRIPTION
DB env variables for 'pg_service_template-container' service in docker-compose.yml are not used at all. This is misleading and leads to the need to look for errors and change the code in several places if the database has changed.

Here is attempt to fix it according to userver docs:
1) [dbconnection](https://userver.tech/d1/d92/classcomponents_1_1Postgres.html?ysclid=lxntb2gssz402118397)
<img width="1322" alt="dbconnection" src="https://github.com/userver-framework/pg_service_template/assets/55500528/9cd4488d-1158-47b7-b973-decfda01142b">


2) [yaml](https://userver.tech/d3/d6c/classyaml__config_1_1YamlConfig.html#ad12308ccdad4df117cf071fd799fa481)
<img width="1322" alt="yaml" src="https://github.com/userver-framework/pg_service_template/assets/55500528/119264d2-1780-4b12-8d5c-3b69f270e7c0">


